### PR TITLE
[Fix] install Capistrano dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,5 +52,10 @@ group :development do
   # gem "spring"
 
   gem 'capistrano', '~> 3.17', '>= 3.17.3', require: false
+  gem 'capistrano-bundler', require: false
+  gem 'capistrano-rails', require: false
+  gem 'capistrano-passenger', require: false
+  gem 'ed25519', '>= 1.2', '< 2.0', require: false
+  gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       tzinfo (~> 2.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
+    bcrypt_pbkdf (1.1.0)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -77,12 +78,20 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
+    capistrano-bundler (2.1.0)
+      capistrano (~> 3.1)
+    capistrano-passenger (0.2.1)
+      capistrano (~> 3.0)
+    capistrano-rails (1.6.3)
+      capistrano (~> 3.1)
+      capistrano-bundler (>= 1.1, < 3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    ed25519 (1.3.0)
     erubi (1.12.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -188,9 +197,14 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  bcrypt_pbkdf (>= 1.0, < 2.0)
   bootsnap
   capistrano (~> 3.17, >= 3.17.3)
+  capistrano-bundler
+  capistrano-passenger
+  capistrano-rails
   debug
+  ed25519 (>= 1.2, < 2.0)
   jbuilder
   pg (~> 1.5, >= 1.5.3)
   puma (~> 5.0)


### PR DESCRIPTION
Error:
```
 bundle exec cap staging deploy:check  
(Backtrace restricted to imported tasks)
cap aborted!
LoadError: cannot load such file -- capistrano/bundler
/Users/anneju/Documents/Rails_Practice/deploy_practices/first_vps_deploy/Capfile:32:in `require'
/Users/anneju/Documents/Rails_Practice/deploy_practices/first_vps_deploy/Capfile:32:in `<top (required)>'
(See full trace by running task with --trace)
```