### PR TITLE
[Fix] Bindle platform for x86_64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.3)
     puma (5.6.6)
       nio4r (~> 2.0)
@@ -195,6 +197,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bcrypt_pbkdf (>= 1.0, < 2.0)


### PR DESCRIPTION
Fix below error
```
 DEBUG [90b00241] 	Your bundle only supports platforms ["x86_64-darwin-21"] but your local platform

is x86_64-linux. Add the current platform to the lockfile with `bundle lock

--add-platform x86_64-linux` and try again.
```

with

```
bundle lock --add-platform x86_64-linux
```