### PR TITLE
[Fix] add staging to database.yml and set path for PG

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -79,6 +79,11 @@ test:
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
+
+staging:
+  <<: *default
+  database: first_vps_deploy_staging
+
 production:
   <<: *default
   database: first_vps_deploy_production

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,10 @@ append :linked_files, 'config/database.yml', 'config/master.key', 'config/secret
 append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'tmp/webpacker', 'public/system', 'vendor', 'storage', 'node_modules', 'public/shared', 'public/uploads'
 
 # Default value for default_env is {}
-# set :default_env, { path: '/opt/ruby/bin:$PATH' }
+set :default_env, {
+  'PATH' => "/usr/pgsql-11/bin:$PATH",
+  'LD_LIBRARY_PATH' => "/usr/pgsql-11/lib:$LD_LIBRARY_PATH"
+}
 
 # Default value for local_user is ENV['USER']
 # set :local_user, -> { `git config user.name`.chomp }


### PR DESCRIPTION
- PG error
```
Unable to find PostgreSQL client library.

Please install libpq or postgresql client package like so:
  sudo apt install libpq-dev
  sudo yum install postgresql-devel
  sudo zypper in postgresql-devel
  sudo pacman -S postgresql-libs

or try again with:
  gem install pg -- --with-pg-config=/path/to/pg_config

or set library paths manually with:
gem install pg -- --with-pg-include=/path/to/libpq-fe.h/
--with-pg-lib=/path/to/libpq.so/
```

- staging db error
```
Caused by:
SSHKit::Command::Failed: rake exit status: 1
rake stdout: Nothing written
rake stderr: config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

rake aborted!
ActiveRecord::AdapterNotSpecified: The `staging` database is not configured for the `staging` environment.

  Available database configurations are:

  default
  development
  test
  production
```